### PR TITLE
sessionId replaced with session_id 

### DIFF
--- a/functions/api/stream.ts
+++ b/functions/api/stream.ts
@@ -120,7 +120,7 @@ async function queryVectorIndex(queries: string[], env: Env, sessionId: string) 
         returnMetadata: "all",
         namespace: "default",
         filter: {
-          sessionId,
+          session_id: sessionId,
         },
       })
     )

--- a/functions/api/upload.ts
+++ b/functions/api/upload.ts
@@ -93,7 +93,7 @@ async function insertVectors(
             id: chunkIds[index],
             values: embedding,
             namespace: "default",
-            metadata: { sessionId, documentId, chunkId: chunkIds[index], text: chunkBatch[index] },
+            metadata: { session_id: sessionId, documentId, chunkId: chunkIds[index], text: chunkBatch[index] },
           }))
         );
 


### PR DESCRIPTION
There was a typo where the variable name `sessionId` was used instead of `session_id`. Which returned no results from vector query